### PR TITLE
Logging fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mtg-spoilers-discord-bot",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "A Discord bot that can be used to automatically post newly spoiled cards for Magic the Gathering as provided by the Scryfall API",
     "main": "bot.js",
     "author": "Jozeevis",

--- a/src/logic/common/logging.ts
+++ b/src/logic/common/logging.ts
@@ -5,8 +5,12 @@ import constants from '../constants';
 /**
  * Logs the given message to the console with a human readable date prefixed
  */
-export function Log(message: string) {
-    let log = `${getReadableDate()} - ${message}`
+export function Log(message: any) {
+    let stringMessage = message as string;
+    if (typeof message === 'object') {
+        stringMessage = JSON.stringify(message);
+    }
+    let log = `${getReadableDate()} - ${stringMessage}`
     console.log(log);
     writeToLogFile(log);
 }
@@ -15,7 +19,11 @@ export function Log(message: string) {
  * Logs the given message to the console as an error with a human readable date prefixed
  */
 export function Error(message: any) {
-    let log = `${getReadableDate()} - ERROR: ${message as string}`
+    let stringMessage = message;
+    if (typeof message === 'object') {
+        stringMessage = JSON.stringify(message);
+    }
+    let log = `${getReadableDate()} - ERROR: ${stringMessage}`
     console.error(log);
     writeToLogFile(log);
 }

--- a/src/logic/common/scryfall.ts
+++ b/src/logic/common/scryfall.ts
@@ -28,12 +28,12 @@ function _parseCard(data: string, name: string): Promise<ICard> {
                 resolve(card);
             }
             else {
-                Log('Expected \'card\' object from Scryfall but could not parse, got the following:');
-                Log(cardData);
+                Error('Expected \'card\' object from Scryfall but could not parse, got the following:');
+                Error(cardData);
                 reject(GET_CARD_ERROR);
             }
         } catch (error) {
-            Log('Something went wrong while trying to parse data from Scryfall.');
+            Error('Something went wrong while trying to parse data from Scryfall.');
             Error(error);
             reject(GET_CARD_ERROR);
         }
@@ -41,7 +41,8 @@ function _parseCard(data: string, name: string): Promise<ICard> {
 }
 
 export async function scryfallGetSet(set: string, ignoreBasics: boolean, callback: (cards: ICard[], args?: { [key: string]: any }) => Promise<string[]>, args?: { [key: string]: any }): Promise<string[]> {
-    const endpoint = `https://api.scryfall.com/cards/search?order=spoiled&q=e%3A${set}&unique=prints`;
+    const query = `e:${set}`;
+    const endpoint = `https://api.scryfall.com/cards/search?order=spoiled&q=${encodeURIComponent(query)}&unique=prints`;
     let data = await makeScryfallAPICall(endpoint).catch((err) => {
         return Promise.reject(err);
     });
@@ -101,18 +102,18 @@ async function _parseSet(data: string, set: string, ignoreBasics: boolean): Prom
                     }
                 }
                 else {
-                    Log(`Expected \'list\' object from Scryfall but got type \'${cardlist.object}\', with the following data`);
-                    Log(cardlistData);
+                    Error(`Expected \'list\' object from Scryfall but got type \'${cardlist.object}\', with the following data`);
+                    Error(cardlistData);
                     reject(GET_SET_ERROR);
                 }
             }
             else {
-                Log('Expected \'list\' object from Scryfall but could not parse, got the following:');
-                Log(cardlistData);
+                Error('Expected \'list\' object from Scryfall but could not parse, got the following:');
+                Error(cardlistData);
                 reject(GET_SET_ERROR);
             }
         } catch (error) {
-            Log('Something went wrong with parsing data from Scryfall.');
+            Error('Something went wrong with parsing data from Scryfall.');
             Error(error);
             reject(GET_SET_ERROR);
         }
@@ -143,7 +144,7 @@ function makeScryfallAPICall(endpoint: string): Promise<string> {
             }
         )
             .on('error', (err) => {
-                Log('Something went wrong while trying to get data from Scryfall.');
+                Error('Something went wrong while trying to get data from Scryfall.');
                 Error(err.message);
                 return reject(GET_SET_ERROR);
             });


### PR DESCRIPTION
Fixed logging showing [object Object] when error was returned from Scryfall API
Moved set query encoding out of endpoint and actually use encodeURIComponent